### PR TITLE
debian: specify a valid ref in local-options

### DIFF
--- a/debian/source/local-options
+++ b/debian/source/local-options
@@ -1,2 +1,2 @@
 extend-diff-ignore = "^[^/]*[.]egg-info/"
-git-ref=v19.2.1
+git-ref=debian/19.2.1


### PR DESCRIPTION
Signed-off-by: Joe MacDonald <joe_macdonald@mentor.com>